### PR TITLE
NFS環境で、PrintLogのたびにログファイルをOpenしなおすのが遅いので、ofstream を保持するように変更

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "cluster.h"
 
 using std::string;
@@ -186,7 +187,7 @@ void Cluster::LaunchWorkers(){
 
 }
 
-int Cluster::Consult(Tree& tree, string log_path){
+int Cluster::Consult(Tree& tree, std::ofstream* log_path){
 
 	SendCommand("bestbranch");
 	std::vector<bool> is_ready;

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -74,6 +74,6 @@ public:
 	}
 
 	void LaunchWorkers();
-	int Consult(Tree& tree, std::string log_path);
+	int Consult(Tree& tree, std::ofstream* log_file);
 
 };

--- a/src/gtp.cpp
+++ b/src/gtp.cpp
@@ -6,6 +6,7 @@
 #include <thread>
 #include <vector>
 #include <iomanip>
+#include <ostream>
 
 #include "gtp.h"
 
@@ -72,8 +73,7 @@ int CallGTP(){
 	if(save_log){
 		std::stringstream ss;
 		ss << "./log/log_" << file_cnt << ".txt";
-		tree.log_path = ss.str();
-		std::ofstream ofs(ss.str()); ofs.close(); // Clear the file.
+		tree.log_file = new std::ofstream(ss.str(), std::ofstream::out);
 	}
 
 	// 3. 入力棋譜がある場合は読みだす
@@ -160,8 +160,7 @@ int CallGTP(){
 				++file_cnt;
 				std::stringstream ss;
 				ss << "./log/log_" << file_cnt << ".txt";
-				tree.log_path = ss.str();
-				std::ofstream ofs(ss.str()); ofs.close(); // Clear the file.
+		                tree.log_file = new std::ofstream(ss.str(), std::ofstream::out);
 			}
 
 			is_playing = is_worker? true : false;
@@ -243,7 +242,7 @@ int CallGTP(){
 				{
 					// 合議の結果を反映する
 					// Reflect the result of consultation.
-					next_move = cluster.Consult(tree, tree.log_path);
+					next_move = cluster.Consult(tree, tree.log_file);
 				}
 			}
 
@@ -289,8 +288,8 @@ int CallGTP(){
 			if(!is_worker){
 
 				PrintBoard(b, next_move);
-				if(tree.log_path != ""){
-					PrintBoard(b, next_move, tree.log_path);
+				if(tree.log_file != NULL){
+					PrintBoard(b, next_move, tree.log_file);
 				}
 
 				if(save_log){
@@ -376,7 +375,7 @@ int CallGTP(){
 			// f. ログファイルを更新する. Update logs.
 			sgf.AddMove(next_move);
 			if(!is_worker){
-				if(tree.log_path != "") PrintBoard(b, next_move, tree.log_path);
+				if(tree.log_file != NULL) PrintBoard(b, next_move, tree.log_file);
 				PrintBoard(b, next_move);
 
 				if(save_log){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,12 +82,9 @@ void SelfMatch() {
 	int prev_move = VNULL;
 	double win_rate = 0.5;
 	std::string log_path = "./log/log_self.txt";
-	tree.log_path = log_path;
+	tree.log_file = new std::ofstream(log_path, std::ofstream::out);
 
 	for(int i=0;i<1;++i){
-		std::ofstream ofs(log_path);
-		ofs.close();
-
 		b.Clear();
 		prev_move = VNULL;
 		win_rate = 0.5;
@@ -96,7 +93,7 @@ void SelfMatch() {
 			next_move = tree.SearchTree(b, 0.0, win_rate, true, false);
 			b.PlayLegal(next_move);
 			PrintBoard(b, next_move);
-			PrintBoard(b, next_move, log_path);
+			PrintBoard(b, next_move, tree.log_file);
 			if (next_move==PASS && prev_move==PASS) break;
 			prev_move = next_move;
 		}

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -66,10 +66,10 @@ void PrintBoard(Board& b, int v){
  *  盤面をファイルに出力する.
  *  Output the board to the file.
  */
-void PrintBoard(Board& b, int v, std::string file_path) {
+void PrintBoard(Board& b, int v, std::ofstream* log_file) {
 
 	//出力するファイルを開く
-	std::ofstream ofs(file_path, std::ios::app);
+	std::ofstream& ofs = *log_file;
 	if (ofs.fail()) return;
 
 	// x座標を出力
@@ -116,8 +116,6 @@ void PrintBoard(Board& b, int v, std::string file_path) {
 	ofs << "  ";
 	for (int x=0;x<BSIZE;++x)  ofs << " " << str_x[x] << " ";
 	ofs << endl;
-
-	ofs.close();
 }
 
 void PrintEF(std::string str, std::ofstream& ofs){
@@ -130,10 +128,9 @@ void PrintEF(std::string str, std::ofstream& ofs){
  *  Output the final score.
  */
 void PrintFinalScore(Board& b, int (&game_cnt)[3], int (&owner_cnt)[2][EBVCNT],
-		int win_pl, double komi, std::string file_path)
+		int win_pl, double komi, std::ofstream* log_file)
 {
-
-	std::ofstream ofs(file_path, std::ios::app);
+	std::ofstream& ofs = *log_file;
 
 	// 1. 死石を表示する
 	//    Display dead stones.

--- a/src/print.h
+++ b/src/print.h
@@ -4,7 +4,7 @@
 #include "board.h"
 
 void PrintBoard(Board& b, int v);
-void PrintBoard(Board& b, int v, std::string file_path);
+void PrintBoard(Board& b, int v, std::ofstream* file_path);
 void PrintFinalScore(Board& b, int (&game_cnt)[3], int (&owner_cnt)[2][EBVCNT],
-		int win_pl, double komi, std::string file_path);
+		int win_pl, double komi, std::ofstream* log_file);
 void PrintOccupancy(int (&game_cnt)[3], int (&owner_cnt)[2][EBVCNT]);

--- a/src/search.h
+++ b/src/search.h
@@ -85,7 +85,7 @@ public:
 	int extension_cnt;
 	std::atomic<bool> stop_think;
 
-	std::string log_path;
+	std::ofstream* log_file;
 
 	Tree();
 	Tree(std::vector<std::string>& sl_path, std::vector<std::string>& vl_path);
@@ -117,7 +117,7 @@ public:
 
 };
 
-void PrintLog(std::string log_path, const char* output_text, ...);
+void PrintLog(std::ofstream* log_path, const char* output_text, ...);
 void SortChildren(Node* pn, std::vector<Child*>& child_list);
 std::string CoordinateString(int v);
 


### PR DESCRIPTION
手元の環境では、思考時間が終わってから結果をGTPに書き込むまでに数秒かかってしまっていたので、ログファイルは開きっぱなしにするよう変更してみました。

副作用として、fprintf -> snprint に変更したため、1行当たりの長さが1024文字に制限されてしまっています。