### PR TITLE
Fix bad condition checking of stone color in IsSelfAtari

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -825,14 +825,14 @@ inline bool Board::IsSelfAtari(int pl, int v) const{
 			lib_bits[etor[v_nbr]/64] |= (0x1ULL<<(etor[v_nbr]%64));
 		}
 		// v‚Ì—×ÚŒð“_‚ª“GÎ. Opponent's stone.
-		else if (color[v_nbr] == int(pl == 0)) {
+		else if (color[v_nbr] == int(pl == 0) + 2) {
 			if (ren[ren_idx[v_nbr]].IsAtari()){
 				if(ren[ren_idx[v_nbr]].size > 1) return false;
 				lib_bits[etor[v_nbr]/64] |= (0x1ULL<<(etor[v_nbr]%64));
 			}
 		}
 		// v‚Ì—×ÚŒð“_‚ªŽ©Î. Player's stone.
-		else if (color[v_nbr] == pl) {
+		else if (color[v_nbr] == pl + 2) {
 			if(ren[ren_idx[v_nbr]].lib_cnt > 2) return false;
 			for(int k=0;k<6;++k){
 				lib_bits[k] |= ren[ren_idx[v_nbr]].lib_bits[k];

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1179,6 +1179,12 @@ void Board::PlayLegal(int v) {
 							int v_s = ren_nbr->lib_atr;
 							for(int i=0;i<4;++i){
 								if(ptn[v_s].IsAtari(i) && ptn[v_s].ColorAt(i) == my_color) ++cap_cnt;
+								else if(!ptn[v_s].IsAtari(i) && ptn[v_s].ColorAt(i) == her + 2) {
+									// If connecting to our stone and live, should not count as snapback.
+									// Add a big number to make inner_cap false.
+									cap_cnt = 4;
+									break;
+								}
 							}
 							if(cap_cnt <= 1 && v_s == ren[atr_idx].lib_atr) inner_cap = true;
 						}


### PR DESCRIPTION
It is a typo forgetting to +2 for color comparison.
This will cause response_move[2] probability not promoted during rollout.